### PR TITLE
ci: fix flaky fork tests by pinning initial base fee to 1 wei

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -13,6 +13,10 @@ module.exports = {
     networks:
         {
             hardhat: {
+                // hardhat's automatic fee estimation can undershoot the next block's
+                // base fee when forking during volatile gas periods; a near-zero base
+                // fee makes local blocks always affordable
+                initialBaseFeePerGas: 1,
                 forking: {
                     url: `https://lb.drpc.live/ogrpc?network=${process.env.FORK_NETWORK}&dkey=${process.env.DRPC_KEY}`,
                     blockNumber: process.env.FORK_BLOCK_NUMBER ? parseInt(process.env.FORK_BLOCK_NUMBER) : undefined,


### PR DESCRIPTION
Hardhat's EDR fills in maxFeePerGas from remote fee history when a tx arrives without fee fields. During volatile gas periods this estimate undershoots the local fork's next-block base fee, rejecting every tx with 'maxFeePerGas too low for the next block'. Starting local blocks at a 1 wei base fee makes any estimate clear it.